### PR TITLE
Add ability to customize each site individually

### DIFF
--- a/templates/html.tpl.php
+++ b/templates/html.tpl.php
@@ -7,6 +7,15 @@
   <?php print $scripts; ?>
 <!--  [if lt IE 9]><script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 <!--  <script >/* html5shiv */ (function(){var t='abbr article aside audio bdi canvas data datalist details figcaption figure footer header hgroup mark meter nav output progress section summary time video'.split(' ');for(var i=t.length;i--;)document.createElement(t[i])})();</script>-->
+
+<?php
+global $base_url;
+$jsPath = DRUPAL_ROOT . "/local/javascript.js";
+$jsURL = $base_url . "/local/javascript.js";
+if (file_exists($jsPath)) {
+  print "<script type=\"text/javascript\" src=\"" . $jsURL . "\"></script>\n";
+}
+?>
 </head>
 <body<?php print $attributes;?>>
   <div class="outer-wrapper">

--- a/templates/html.tpl.php
+++ b/templates/html.tpl.php
@@ -15,6 +15,12 @@ $jsURL = $base_url . "/local/javascript.js";
 if (file_exists($jsPath)) {
   print "<script type=\"text/javascript\" src=\"" . $jsURL . "\"></script>\n";
 }
+
+$cssPath = DRUPAL_ROOT . "/local/styles.css";
+$cssURL = $base_url . "/local/styles.css";
+if (file_exists($cssPath)) {
+  print "<link type=\"text/css\" rel=\"stylesheet\" media=\"all\" href=\"" . $cssURL . "\" />\n";
+}
 ?>
 </head>
 <body<?php print $attributes;?>>

--- a/templates/html.tpl.php
+++ b/templates/html.tpl.php
@@ -9,10 +9,12 @@
 <!--  <script >/* html5shiv */ (function(){var t='abbr article aside audio bdi canvas data datalist details figcaption figure footer header hgroup mark meter nav output progress section summary time video'.split(' ');for(var i=t.length;i--;)document.createElement(t[i])})();</script>-->
 </head>
 <body<?php print $attributes;?>>
+  <div class="outer-wrapper">
 	<!--[if lt IE 9]><div class="iecomp"><![endif]-->
   		<?php print $page_top; ?>
   		<?php print $page; ?>
   		<?php print $page_bottom; ?>
 	<!--[if lt IE 9]></div><![endif]-->
+  </div>
 </body>
 </html>

--- a/templates/html.tpl.php
+++ b/templates/html.tpl.php
@@ -21,6 +21,12 @@ $cssURL = $base_url . "/local/styles.css";
 if (file_exists($cssPath)) {
   print "<link type=\"text/css\" rel=\"stylesheet\" media=\"all\" href=\"" . $cssURL . "\" />\n";
 }
+
+$printPath = DRUPAL_ROOT . "/local/print.css";
+$printURL = $base_url . "/local/print.css";
+if (file_exists($printPath)) {
+  print "<link type=\"text/css\" rel=\"stylesheet\" media=\"print\" href=\"" . $printURL . "\" />\n";
+}
 ?>
 </head>
 <body<?php print $attributes;?>>

--- a/templates/region--branding.tpl.php
+++ b/templates/region--branding.tpl.php
@@ -3,6 +3,13 @@
   <?php if ($linked_logo_img || $site_name || $site_slogan): ?>
     <div class="branding-data clearfix">
 
+<?php
+$logoPath = DRUPAL_ROOT . "/local/logo.htm";
+
+if (file_exists($logoPath)) {
+  include $logoPath;
+} else { ?>
+
       <div id="isu_wordmark">
         <a accesskey="1" class="nameplate" href="http://www.extension.iastate.edu" title="Iowa State University Extension and Outreach Homepage"><img src="<?php print base_path(); ?>sites/all/themes/suitcaseext/images/sprite.png" alt="Iowa State University"></a></div>
       <?php if ($site_name || $site_slogan): ?>
@@ -19,6 +26,7 @@
           <?php endif; ?>
         </hgroup>
       <?php endif; ?>
+<?php } ?>
     </div>
   <?php endif; ?>
   <?php print $content; ?>

--- a/templates/section--header.tpl.php
+++ b/templates/section--header.tpl.php
@@ -19,7 +19,6 @@
                       <li><a href="http://www.extension.iastate.edu/content/contact-us">Contact Us</a></li>
                       <li class="last"><a href="http://www.extension.iastate.edu/content/county-offices">Offices</a></li>
                     </ul>
-                </ul>
               </div>
             </div>
           </div>

--- a/templates/section--header.tpl.php
+++ b/templates/section--header.tpl.php
@@ -10,6 +10,15 @@
               </ul>
               <div class="wd-ribbon-menu-stack">
                 
+<?php
+global $base_url;
+$menuPath = DRUPAL_ROOT . "/local/menu.htm";
+
+if (file_exists($menuPath)) {
+  include $menuPath;
+}
+ else { ?>
+
                     <ul class="wd-ribbon-menu">
                       <li class="first"><a href="http://www.iastate.edu/">ISU</a></li>
                       <li><a href="http://www.extension.iastate.edu/articles">News</a></li>
@@ -19,6 +28,8 @@
                       <li><a href="http://www.extension.iastate.edu/content/contact-us">Contact Us</a></li>
                       <li class="last"><a href="http://www.extension.iastate.edu/content/county-offices">Offices</a></li>
                     </ul>
+<?php } ?>
+
               </div>
             </div>
           </div>


### PR DESCRIPTION
This pull request adds code that will load local files into the theme as sites are being built. This allows us to customize each site without having to fork the main theme for each site. It looks for files in the "local" directory at drupal root, and if it finds the files, it includes them. The files it looks for are:
- javascript.js - Used for javascript for the local site
- styles.css - Used for styles for the local site
- print.css - Used for print styles for the local site
- logo.htm - Used to replace the wordmark (logo) on the local site
- menu.htm - Used to replace the "black bar" menu on the local site
